### PR TITLE
Core: Retry policy and exponential backoff

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,5 @@ export {
 	type RetryPolicyInput,
 	RetryPolicySchema,
 } from "./job";
+
+export { type RetryState, computeBackoff, shouldRetry } from "./retry";

--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -24,13 +24,14 @@ describe("RequestBodySchema", () => {
 			attempts: 3,
 			backoff: "exponential",
 			initial_delay_ms: 1000,
+			max_delay_ms: 30000,
 		});
 	});
 
 	it("accepts a request with explicit retry policy", () => {
 		const retry = { attempts: 5, backoff: "exponential" as const, initial_delay_ms: 2000 };
 		const result = RequestBodySchema.parse({ ...validRequest, retry });
-		expect(result.retry).toEqual(retry);
+		expect(result.retry).toEqual({ ...retry, max_delay_ms: 30000 });
 	});
 
 	it("accepts a request with callback headers", () => {

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -30,12 +30,13 @@ export type Callback = z.infer<typeof CallbackSchema>;
  * Zod schema for retry policy.
  *
  * Controls how many times Lampas retries failed deliveries and the backoff strategy.
- * Fields have defaults: attempts=3, backoff="exponential", initial_delay_ms=1000.
+ * Fields have defaults: attempts=3, backoff="exponential", initial_delay_ms=1000, max_delay_ms=30000.
  */
 export const RetryPolicySchema = z.object({
 	attempts: z.number().int().min(1, "Retry attempts must be at least 1").default(3),
 	backoff: z.literal("exponential").default("exponential"),
 	initial_delay_ms: z.number().int().min(0, "Initial delay must be non-negative").default(1000),
+	max_delay_ms: z.number().int().min(1, "Max delay must be at least 1ms").default(30000),
 });
 
 /** Retry policy after Zod defaults have been applied. */

--- a/packages/core/src/retry.test.ts
+++ b/packages/core/src/retry.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { RetryPolicy } from "./job";
+import { RetryPolicySchema } from "./job";
+import { computeBackoff, shouldRetry } from "./retry";
+
+const defaultPolicy: RetryPolicy = RetryPolicySchema.parse({});
+
+describe("computeBackoff", () => {
+	it("returns increasing delays for successive attempts", () => {
+		const d0 = computeBackoff(0, defaultPolicy);
+		const d1 = computeBackoff(1, defaultPolicy);
+		const d2 = computeBackoff(2, defaultPolicy);
+
+		expect(d0).toBeLessThan(d1);
+		expect(d1).toBeLessThan(d2);
+	});
+
+	it("uses initial_delay_ms * 2^attempt formula", () => {
+		const policy: RetryPolicy = RetryPolicySchema.parse({
+			initial_delay_ms: 500,
+		});
+		expect(computeBackoff(0, policy)).toBe(500);
+		expect(computeBackoff(1, policy)).toBe(1000);
+		expect(computeBackoff(2, policy)).toBe(2000);
+		expect(computeBackoff(3, policy)).toBe(4000);
+	});
+
+	it("never exceeds max_delay_ms", () => {
+		const policy: RetryPolicy = RetryPolicySchema.parse({
+			initial_delay_ms: 1000,
+			max_delay_ms: 5000,
+		});
+		expect(computeBackoff(0, policy)).toBe(1000);
+		expect(computeBackoff(1, policy)).toBe(2000);
+		expect(computeBackoff(2, policy)).toBe(4000);
+		expect(computeBackoff(3, policy)).toBe(5000);
+		expect(computeBackoff(10, policy)).toBe(5000);
+	});
+
+	it("caps at default max_delay_ms of 30000", () => {
+		expect(computeBackoff(100, defaultPolicy)).toBe(30000);
+	});
+});
+
+describe("shouldRetry", () => {
+	it("returns true when attempts remain", () => {
+		const policy: RetryPolicy = RetryPolicySchema.parse({ attempts: 3 });
+		expect(shouldRetry(0, policy)).toBe(true);
+		expect(shouldRetry(1, policy)).toBe(true);
+		expect(shouldRetry(2, policy)).toBe(true);
+	});
+
+	it("returns false when attempts are exhausted", () => {
+		const policy: RetryPolicy = RetryPolicySchema.parse({ attempts: 3 });
+		expect(shouldRetry(3, policy)).toBe(false);
+		expect(shouldRetry(4, policy)).toBe(false);
+	});
+
+	it("works with single attempt", () => {
+		const policy: RetryPolicy = RetryPolicySchema.parse({ attempts: 1 });
+		expect(shouldRetry(0, policy)).toBe(true);
+		expect(shouldRetry(1, policy)).toBe(false);
+	});
+});
+
+describe("RetryPolicySchema defaults", () => {
+	it("applies default values", () => {
+		const policy = RetryPolicySchema.parse({});
+		expect(policy.attempts).toBe(3);
+		expect(policy.backoff).toBe("exponential");
+		expect(policy.initial_delay_ms).toBe(1000);
+		expect(policy.max_delay_ms).toBe(30000);
+	});
+});

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,38 @@
+import type { RetryPolicy } from "./job";
+
+/**
+ * Tracks the current state of retry attempts for a callback delivery.
+ */
+export interface RetryState {
+	/** Number of attempts made so far (0 = not yet attempted). */
+	attempt: number;
+	/** ISO 8601 timestamp of the next scheduled retry, or null if no more retries. */
+	next_retry_at: string | null;
+}
+
+/**
+ * Computes the backoff delay in milliseconds for a given attempt using exponential backoff.
+ *
+ * Formula: `min(initial_delay_ms * 2^attempt, max_delay_ms)`
+ *
+ * @param attempt - The zero-based attempt number
+ * @param policy - The retry policy controlling backoff parameters
+ * @returns Delay in milliseconds before the next retry
+ */
+export function computeBackoff(attempt: number, policy: RetryPolicy): number {
+	const delay = policy.initial_delay_ms * 2 ** attempt;
+	return Math.min(delay, policy.max_delay_ms);
+}
+
+/**
+ * Determines whether another retry attempt should be made.
+ *
+ * Returns true if the current attempt number is less than the policy's maximum attempts.
+ *
+ * @param attempt - The zero-based attempt number (number of attempts already made)
+ * @param policy - The retry policy controlling the maximum number of attempts
+ * @returns Whether another attempt should be made
+ */
+export function shouldRetry(attempt: number, policy: RetryPolicy): boolean {
+	return attempt < policy.attempts;
+}


### PR DESCRIPTION
Closes #4

## What this does

Adds retry logic for callback delivery: `computeBackoff` (exponential backoff with max cap), `shouldRetry` (attempt exhaustion check), and `RetryState` type. Also adds `max_delay_ms` field to `RetryPolicySchema` with a default of 30000ms.

## Design alignment

- **Principle 4** (callbacks are best-effort with bounded retry): Retry is bounded by `attempts` and `max_delay_ms`. No infinite retry. No dead-letter queue.

## Validation performed

- `npm run build` — compiles cleanly
- `npm run check` — biome passes (0 errors)
- `npm test` — 28 tests pass (8 new retry tests + 20 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)