### PR TITLE
Cloudflare: Worker entry point and routing (#6)

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -16,5 +16,8 @@
 	},
 	"dependencies": {
 		"@lampas/core": "workspace:*"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20260306.1"
 	}
 }

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,1 +1,3 @@
 // @lampas/cloudflare — Cloudflare Workers + Durable Objects backend
+
+export { handleRequest } from "./worker";

--- a/packages/cloudflare/src/worker.test.ts
+++ b/packages/cloudflare/src/worker.test.ts
@@ -1,0 +1,209 @@
+import type { Job, JobStore, RequestBody } from "@lampas/core";
+import { describe, expect, it } from "vitest";
+import { handleRequest } from "./worker";
+
+const validRequest = {
+	target: "https://api.example.com/data",
+	forward_headers: { Authorization: "Bearer tok_123" },
+	callbacks: [{ url: "https://hook.example.com/callback" }],
+	body: { key: "value" },
+};
+
+function makeJob(id: string, request: RequestBody): Job {
+	return {
+		id,
+		status: "queued",
+		created_at: "2024-01-01T00:00:00.000Z",
+		updated_at: "2024-01-01T00:00:00.000Z",
+		request,
+	};
+}
+
+function mockJobStore(jobs: Map<string, Job> = new Map()): JobStore {
+	return {
+		async createJob(request: RequestBody): Promise<Job> {
+			const job = makeJob("test-job-id", request);
+			jobs.set(job.id, job);
+			return job;
+		},
+		async getJob(id: string): Promise<Job | null> {
+			return jobs.get(id) ?? null;
+		},
+		async updateJobStatus(id: string, status: Job["status"]): Promise<void> {
+			const job = jobs.get(id);
+			if (job) job.status = status;
+		},
+	};
+}
+
+function post(path: string, body: unknown): Request {
+	return new Request(`http://localhost${path}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function get(path: string): Request {
+	return new Request(`http://localhost${path}`, { method: "GET" });
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test helper for json assertions
+async function json(res: Response): Promise<any> {
+	return res.json();
+}
+
+describe("POST /forward", () => {
+	it("returns 202 with job_id and status for a valid request", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(post("/forward", validRequest), store);
+
+		expect(res.status).toBe(202);
+		const body = await json(res);
+		expect(body).toEqual({ job_id: "test-job-id", status: "queued" });
+	});
+
+	it("returns 400 when body is not valid JSON", async () => {
+		const store = mockJobStore();
+		const req = new Request("http://localhost/forward", {
+			method: "POST",
+			body: "not json",
+		});
+		const res = await handleRequest(req, store);
+
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toBe("Request body must be valid JSON");
+	});
+
+	it("returns 400 when target is missing", async () => {
+		const store = mockJobStore();
+		const { target: _, ...noTarget } = validRequest;
+		const res = await handleRequest(post("/forward", noTarget), store);
+
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toBeDefined();
+	});
+
+	it("returns 400 when target is not a valid URL", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(
+			post("/forward", { ...validRequest, target: "not-a-url" }),
+			store,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toContain("Target must be a valid URL");
+	});
+
+	it("returns 400 when callbacks is empty", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(post("/forward", { ...validRequest, callbacks: [] }), store);
+
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toContain("At least one callback is required");
+	});
+
+	it("returns 400 when callbacks is missing", async () => {
+		const store = mockJobStore();
+		const { callbacks: _, ...noCallbacks } = validRequest;
+		const res = await handleRequest(post("/forward", noCallbacks), store);
+
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when forward_headers is missing", async () => {
+		const store = mockJobStore();
+		const { forward_headers: _, ...noHeaders } = validRequest;
+		const res = await handleRequest(post("/forward", noHeaders), store);
+
+		expect(res.status).toBe(400);
+	});
+});
+
+describe("GET /jobs/:id", () => {
+	it("returns 200 with job data when job exists", async () => {
+		const jobs = new Map<string, Job>();
+		const store = mockJobStore(jobs);
+		// Pre-populate a job
+		const job = makeJob("existing-job", validRequest as RequestBody);
+		jobs.set("existing-job", job);
+
+		const res = await handleRequest(get("/jobs/existing-job"), store);
+
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body.id).toBe("existing-job");
+		expect(body.status).toBe("queued");
+	});
+
+	it("returns 404 when job does not exist", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(get("/jobs/nonexistent"), store);
+
+		expect(res.status).toBe(404);
+		const body = await json(res);
+		expect(body.error).toBe("Job not found");
+	});
+});
+
+describe("method not allowed", () => {
+	it("returns 405 for GET /forward", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(get("/forward"), store);
+
+		expect(res.status).toBe(405);
+		const body = await json(res);
+		expect(body.error).toBe("Method not allowed");
+	});
+
+	it("returns 405 for POST /jobs/:id", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(post("/jobs/some-id", {}), store);
+
+		expect(res.status).toBe(405);
+		const body = await json(res);
+		expect(body.error).toBe("Method not allowed");
+	});
+});
+
+describe("unknown routes", () => {
+	it("returns 404 for unrecognized paths", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(get("/unknown"), store);
+
+		expect(res.status).toBe(404);
+		const body = await json(res);
+		expect(body.error).toBe("Not found");
+	});
+});
+
+describe("CORS", () => {
+	it("returns 204 with CORS headers for OPTIONS preflight", async () => {
+		const store = mockJobStore();
+		const req = new Request("http://localhost/forward", { method: "OPTIONS" });
+		const res = await handleRequest(req, store);
+
+		expect(res.status).toBe(204);
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+		expect(res.headers.get("Access-Control-Allow-Headers")).toContain("Content-Type");
+	});
+
+	it("includes CORS headers on error responses", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(get("/unknown"), store);
+
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+	});
+
+	it("includes CORS headers on success responses", async () => {
+		const store = mockJobStore();
+		const res = await handleRequest(post("/forward", validRequest), store);
+
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+	});
+});

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -1,0 +1,86 @@
+import { type JobStore, RequestBodySchema } from "@lampas/core";
+
+/** Adds CORS headers to a response. */
+function corsHeaders(response: Response): Response {
+	response.headers.set("Access-Control-Allow-Origin", "*");
+	response.headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+	response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+	return response;
+}
+
+/** Creates a JSON error response with CORS headers. */
+function errorResponse(status: number, message: string): Response {
+	return corsHeaders(
+		new Response(JSON.stringify({ error: message }), {
+			status,
+			headers: { "Content-Type": "application/json" },
+		}),
+	);
+}
+
+/** Creates a JSON success response with CORS headers. */
+function jsonResponse(status: number, body: unknown): Response {
+	return corsHeaders(
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { "Content-Type": "application/json" },
+		}),
+	);
+}
+
+async function handleForward(request: Request, jobStore: JobStore): Promise<Response> {
+	let rawBody: unknown;
+	try {
+		rawBody = await request.json();
+	} catch {
+		return errorResponse(400, "Request body must be valid JSON");
+	}
+
+	const result = RequestBodySchema.safeParse(rawBody);
+	if (!result.success) {
+		const messages = result.error.issues.map((i) => i.message);
+		return errorResponse(400, messages.join("; "));
+	}
+
+	const job = await jobStore.createJob(result.data);
+	return jsonResponse(202, { job_id: job.id, status: job.status });
+}
+
+async function handleGetJob(jobId: string, jobStore: JobStore): Promise<Response> {
+	const job = await jobStore.getJob(jobId);
+	if (!job) {
+		return errorResponse(404, "Job not found");
+	}
+	return jsonResponse(200, job);
+}
+
+/**
+ * Routes an incoming HTTP request to the appropriate handler.
+ *
+ * Supports POST /forward and GET /jobs/:id. Returns proper HTTP error
+ * responses for validation failures, wrong methods, and unknown routes.
+ */
+export async function handleRequest(request: Request, jobStore: JobStore): Promise<Response> {
+	if (request.method === "OPTIONS") {
+		return corsHeaders(new Response(null, { status: 204 }));
+	}
+
+	const url = new URL(request.url);
+
+	if (url.pathname === "/forward") {
+		if (request.method !== "POST") {
+			return errorResponse(405, "Method not allowed");
+		}
+		return handleForward(request, jobStore);
+	}
+
+	const jobMatch = url.pathname.match(/^\/jobs\/([^/]+)$/);
+	if (jobMatch) {
+		if (request.method !== "GET") {
+			return errorResponse(405, "Method not allowed");
+		}
+		return handleGetJob(jobMatch[1], jobStore);
+	}
+
+	return errorResponse(404, "Not found");
+}

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -4,6 +4,7 @@
 		"module": "ES2022",
 		"moduleResolution": "bundler",
 		"lib": ["ES2022"],
+		"types": ["@cloudflare/workers-types"],
 		"outDir": "./dist",
 		"rootDir": "./src",
 		"strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,10 @@ importers:
       '@lampas/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260306.1
+        version: 4.20260306.1
 
   packages/core:
     dependencies:
@@ -84,6 +88,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260306.1':
+    resolution: {integrity: sha512-1gtiB0nm0Uji6VKHprvL1ZyFtdHZSR907lU2fbBioMurJAF4tQPoafJFJp4oeViUiMVUEqkp0Eh0dcbcKoHoow==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -665,6 +672,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@cloudflare/workers-types@4.20260306.1': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true


### PR DESCRIPTION
Closes #6

## What this does

Implements the stateless Cloudflare Worker HTTP entry point for Lampas. The worker handles `POST /forward` (validates request body against core schemas, delegates job creation to a `JobStore`, returns 202 with job ID) and `GET /jobs/:id` (retrieves job state or returns 404). Includes CORS preflight support and proper HTTP error responses (400/404/405).

## Design alignment

- **Principle 1 (request is the spec):** The worker validates the self-contained request spec via `RequestBodySchema` and passes it through to the `JobStore`. No server-side configuration.
- **Principle 2 (credentials never stored):** The worker receives `forward_headers` in the request body and passes them to the `JobStore` without persisting them. No credential ever touches durable storage in the worker layer.

## Validation performed

```
$ pnpm run build   # ✅ both core and cloudflare compile cleanly
$ pnpm run check   # ✅ biome check passes (0 errors)
$ pnpm run test    # ✅ 43 tests pass (15 new worker tests)
```

Test coverage:
- Valid POST /forward → 202 with job_id and status
- Invalid JSON → 400
- Missing/invalid target, callbacks, forward_headers → 400
- GET /jobs/:id found → 200, not found → 404
- Wrong HTTP methods → 405
- Unknown routes → 404
- CORS preflight → 204 with headers
- CORS headers present on all responses