### PR TITLE
feat: deployment config, CI deploy workflow, and README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run check
+      - run: pnpm run test
+      - name: Deploy to Cloudflare
+        working-directory: packages/cloudflare
+        run: pnpm deploy:production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Lampas
+
+Turn any API into a webhook. Send a request to Lampas specifying a target API, callback URLs, and a retry policy. Lampas makes the upstream call and delivers the response to your callbacks. Your caller can exit immediately.
+
+## How it works
+
+Lampas acts as a proxy: you POST a job describing what to call and where to deliver the result. Lampas calls the target, wraps the response in an envelope with metadata, and POSTs it to each callback URL with exponential backoff on failure.
+
+## Quick start
+
+```bash
+curl https://lampas.dev/forward \
+  -H "content-type: application/json" \
+  -d '{
+    "target": "https://api.anthropic.com/v1/messages",
+    "forward_headers": {
+      "x-api-key": "$ANTHROPIC_API_KEY",
+      "anthropic-version": "2023-06-01"
+    },
+    "callbacks": [
+      { "url": "https://your-webhook.example.com" }
+    ],
+    "retry": { "attempts": 3, "backoff": "exponential" },
+    "body": {
+      "model": "claude-opus-4-5",
+      "max_tokens": 1024,
+      "messages": [{"role": "user", "content": "Hello."}]
+    }
+  }'
+```
+
+Lampas returns a job ID immediately:
+
+```json
+{ "job_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }
+```
+
+Check job status:
+
+```bash
+curl https://lampas.dev/jobs/<job_id>
+```
+
+Your callback receives an envelope like:
+
+```json
+{
+  "lampas_job_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "lampas_status": "completed",
+  "lampas_target": "https://api.anthropic.com/v1/messages",
+  "lampas_delivered_at": "2026-03-06T08:31:00Z",
+  "response_status": 200,
+  "response_headers": { "content-type": "application/json" },
+  "response_body": { "..." : "..." }
+}
+```
+
+## Project structure
+
+```
+packages/
+  core/        — Shared types, schemas (Zod), and retry logic
+  cloudflare/  — Cloudflare Worker + Durable Object implementation
+```
+
+## Development
+
+```bash
+pnpm install
+pnpm run build
+pnpm run check
+pnpm run test
+```
+
+### Local dev server
+
+```bash
+cd packages/cloudflare
+pnpm exec wrangler dev
+```
+
+## Deploy
+
+Lampas deploys to Cloudflare Workers with Durable Objects.
+
+### Automatic (CI)
+
+Pushes to `main` trigger the deploy workflow. Requires a `CLOUDFLARE_API_TOKEN` secret in GitHub.
+
+### Manual
+
+```bash
+cd packages/cloudflare
+pnpm deploy:production
+```
+
+This deploys to the production environment with the `lampas.dev` route.
+
+## Architecture
+
+See [VISION.md](VISION.md) for design principles and [ARTICLE.md](ARTICLE.md) for the motivation behind the project.
+
+## License
+
+MIT

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -14,7 +14,9 @@
 	"scripts": {
 		"build": "tsc -p tsconfig.json",
 		"test": "vitest run",
-		"test:e2e": "vitest run --config vitest.e2e.config.ts"
+		"test:e2e": "vitest run --config vitest.e2e.config.ts",
+		"deploy": "wrangler deploy",
+		"deploy:production": "wrangler deploy --env production"
 	},
 	"dependencies": {
 		"@lampas/core": "workspace:*"

--- a/packages/cloudflare/wrangler.toml
+++ b/packages/cloudflare/wrangler.toml
@@ -9,3 +9,7 @@ class_name = "JobDO"
 [[migrations]]
 tag = "v1"
 new_classes = ["JobDO"]
+
+# Production environment
+[env.production]
+routes = [{ pattern = "lampas.dev/*", zone_name = "lampas.dev" }]


### PR DESCRIPTION
Closes #9

## Summary
- **wrangler.toml**: Added production environment with `lampas.dev/*` route config
- **package.json**: Added `deploy` and `deploy:production` npm scripts
- **deploy.yml**: GitHub Actions workflow that builds, checks, tests, then deploys to Cloudflare on push to main (requires `CLOUDFLARE_API_TOKEN` secret)
- **README.md**: Root README with project description, curl quick-start example, project structure, and dev/deploy instructions

## Design alignment
- **Principle 7** (Phase 0 backend is Cloudflare Workers + Durable Objects): This makes deployment real with proper route config and CI pipeline.

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run check` passes
- [x] All unit tests pass (28 core + 22 cloudflare)
- [ ] After merge, verify `CLOUDFLARE_API_TOKEN` secret is set in GitHub repo settings
- [ ] After merge, verify deploy workflow runs successfully
- [ ] Verify `lampas.dev/forward` accepts requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)