### PR TITLE
feat: add method and timeout_ms to request schema

### DIFF
--- a/packages/cloudflare/src/job-do.test.ts
+++ b/packages/cloudflare/src/job-do.test.ts
@@ -8,14 +8,12 @@ const UPSTREAM_URL = `${UPSTREAM_ORIGIN}${UPSTREAM_PATH}`;
 const CB_ORIGIN = "https://hook.example.com";
 const CB_PATH = "/callback";
 const CB_URL = `${CB_ORIGIN}${CB_PATH}`;
-
 const validReq = {
 	target: UPSTREAM_URL,
 	forward_headers: { Authorization: "Bearer tok_123" },
 	callbacks: [{ url: CB_URL }],
 	body: { key: "value" },
 };
-
 type AnyRec = Record<string, unknown>;
 const stub = (id: string) => env.JOB_DO.get(env.JOB_DO.idFromName(id));
 
@@ -38,10 +36,10 @@ async function createJob(
 	return res;
 }
 
-function mockUpstream(status = 200, body: unknown = { result: "ok" }) {
+function mockUpstream(status = 200, body: unknown = { result: "ok" }, method = "POST") {
 	fetchMock
 		.get(UPSTREAM_ORIGIN)
-		.intercept({ path: UPSTREAM_PATH, method: "POST" })
+		.intercept({ path: UPSTREAM_PATH, method })
 		.reply(status, JSON.stringify(body), {
 			headers: { "content-type": "application/json" },
 		});
@@ -119,7 +117,6 @@ describe("job creation", () => {
 		expect(res.status).toBe(400);
 	});
 });
-
 describe("status query", () => {
 	it("returns job state", async () => {
 		const s = stub("status-ok");
@@ -141,7 +138,6 @@ describe("status query", () => {
 		expect(res.status).toBe(404);
 	});
 });
-
 describe("upstream execution", () => {
 	it("calls upstream and wipes forward_headers", async () => {
 		mockUpstream();
@@ -259,6 +255,32 @@ describe("retry exhaustion", () => {
 			await i.alarm();
 			expect(((await st.storage.get("cb:0")) as CallbackState).status).toBe("failed");
 			expect(((await st.storage.get("job")) as AnyRec).status).toBe("failed");
+		});
+	});
+});
+
+describe("HTTP method", () => {
+	it("uses GET when method is GET and ignores body", async () => {
+		mockUpstream(200, { result: "ok" }, "GET");
+		mockCb();
+		const s = stub("get-method");
+		const req = { ...validReq, method: "GET" };
+		await runInDurableObject(s, async (i: JobDO, st) => {
+			await createJob(i, st, "get-method", req);
+			await i.alarm();
+			expect(((await st.storage.get("upstream_response")) as AnyRec).status).toBe(200);
+			expect(((await st.storage.get("job")) as AnyRec).status).toBe("completed");
+		});
+	});
+
+	it("defaults to POST when method is omitted", async () => {
+		mockUpstream();
+		mockCb();
+		const s = stub("default-post");
+		await runInDurableObject(s, async (i: JobDO, st) => {
+			await createJob(i, st, "default-post");
+			await i.alarm();
+			expect(((await st.storage.get("upstream_response")) as AnyRec).status).toBe(200);
 		});
 	});
 });

--- a/packages/cloudflare/src/job-do.ts
+++ b/packages/cloudflare/src/job-do.ts
@@ -117,11 +117,20 @@ export class JobDO implements DurableObject {
 
 		let upstream: UpstreamResponse;
 		try {
+			const method = job.request.method ?? "POST";
+			const hasBody = method !== "GET" && method !== "HEAD";
+			const controller = new AbortController();
+			const timeoutMs = job.request.timeout_ms ?? 30000;
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+
 			const response = await fetch(job.request.target, {
-				method: "POST",
+				method,
 				headers: forwardHeaders ?? {},
-				body: serializeBody(job.request.body),
+				body: hasBody ? serializeBody(job.request.body) : null,
+				signal: controller.signal,
 			});
+
+			clearTimeout(timer);
 
 			const headers: Record<string, string> = {};
 			response.headers.forEach((v, k) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export {
 export {
 	type Callback,
 	CallbackSchema,
+	type HttpMethod,
+	HttpMethodSchema,
 	type Job,
 	JobSchema,
 	type JobStatus,

--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -97,4 +97,39 @@ describe("RequestBodySchema", () => {
 		const result = RequestBodySchema.safeParse({ ...validRequest, body: null });
 		expect(result.success).toBe(true);
 	});
+
+	it("defaults method to POST when omitted", () => {
+		const result = RequestBodySchema.parse(validRequest);
+		expect(result.method).toBe("POST");
+	});
+
+	it("accepts explicit method", () => {
+		const result = RequestBodySchema.parse({ ...validRequest, method: "GET" });
+		expect(result.method).toBe("GET");
+	});
+
+	it("rejects invalid method", () => {
+		const result = RequestBodySchema.safeParse({ ...validRequest, method: "INVALID" });
+		expect(result.success).toBe(false);
+	});
+
+	it("defaults timeout_ms to 30000 when omitted", () => {
+		const result = RequestBodySchema.parse(validRequest);
+		expect(result.timeout_ms).toBe(30000);
+	});
+
+	it("accepts explicit timeout_ms", () => {
+		const result = RequestBodySchema.parse({ ...validRequest, timeout_ms: 60000 });
+		expect(result.timeout_ms).toBe(60000);
+	});
+
+	it("rejects timeout_ms below 1000", () => {
+		const result = RequestBodySchema.safeParse({ ...validRequest, timeout_ms: 500 });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects timeout_ms above 300000", () => {
+		const result = RequestBodySchema.safeParse({ ...validRequest, timeout_ms: 400000 });
+		expect(result.success).toBe(false);
+	});
 });

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -46,6 +46,16 @@ export type RetryPolicy = z.infer<typeof RetryPolicySchema>;
 export type RetryPolicyInput = z.input<typeof RetryPolicySchema>;
 
 /**
+ * Allowed HTTP methods for the upstream request.
+ */
+export const HttpMethodSchema = z
+	.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
+	.default("POST");
+
+/** Union of allowed HTTP method values. */
+export type HttpMethod = z.infer<typeof HttpMethodSchema>;
+
+/**
  * Zod schema for the Lampas request body.
  *
  * Contains the complete execution specification: what to call, where to deliver
@@ -53,9 +63,16 @@ export type RetryPolicyInput = z.input<typeof RetryPolicySchema>;
  */
 export const RequestBodySchema = z.object({
 	target: z.string().url("Target must be a valid URL"),
+	method: HttpMethodSchema,
 	forward_headers: z.record(z.string(), z.string()),
 	callbacks: z.array(CallbackSchema).min(1, "At least one callback is required"),
 	retry: RetryPolicySchema.optional(),
+	timeout_ms: z
+		.number()
+		.int()
+		.min(1000, "Timeout must be at least 1000ms")
+		.max(300000, "Timeout must be at most 300000ms")
+		.default(30000),
 	body: z.unknown(),
 });
 


### PR DESCRIPTION
Closes #18
Closes #19

## Summary
- Added `method` field to `RequestBodySchema` — supports GET, POST, PUT, PATCH, DELETE, HEAD (defaults to POST for backwards compatibility)
- Added `timeout_ms` field — bounds upstream call duration (default 30s, min 1s, max 5min) using AbortController
- GET/HEAD requests automatically omit the body from the upstream fetch

## Design alignment
- **Principle 1** (request is the spec): HTTP method and timeout are now part of the execution specification, closing the gap discovered during live testing.

## Validation performed
- `pnpm run build` — passes
- `pnpm run check` — passes (biome lint/format clean)
- `pnpm exec vitest run` — 35 core tests pass (7 new)
- `pnpm --filter @lampas/cloudflare test` — 24 cloudflare tests pass (2 new)
- All files under 300 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)