### PR TITLE
feat: SSRF protection with configurable private network policy

### DIFF
--- a/packages/cloudflare/src/delivery.ts
+++ b/packages/cloudflare/src/delivery.ts
@@ -1,0 +1,212 @@
+import {
+	type Callback,
+	type Envelope,
+	type Job,
+	type JobStatus,
+	type RetryPolicy,
+	RetryPolicySchema,
+	type UpstreamResponse,
+	buildEnvelope,
+	computeBackoff,
+	shouldRetry,
+} from "@lampas/core";
+import { serializeBody } from "./http.js";
+
+/** Per-callback delivery tracking state. */
+export interface CallbackState {
+	status: "pending" | "delivered" | "failed";
+	attempts: number;
+	next_retry_at: number | null;
+}
+
+const DEFAULT_RETRY_POLICY: RetryPolicy = RetryPolicySchema.parse({});
+
+/** Execute the upstream request and deliver the envelope to all callbacks. */
+export async function executeAndDeliver(storage: DurableObjectStorage, job: Job): Promise<void> {
+	await updateStatus(storage, "in_progress");
+
+	const forwardHeaders = await storage.get<Record<string, string>>("forward_headers");
+
+	let upstream: UpstreamResponse;
+	try {
+		const method = job.request.method ?? "POST";
+		const hasBody = method !== "GET" && method !== "HEAD";
+		const controller = new AbortController();
+		const timeoutMs = job.request.timeout_ms ?? 30000;
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+		const response = await fetch(job.request.target, {
+			method,
+			headers: forwardHeaders ?? {},
+			body: hasBody ? serializeBody(job.request.body) : null,
+			signal: controller.signal,
+		});
+
+		clearTimeout(timer);
+
+		const headers: Record<string, string> = {};
+		response.headers.forEach((v, k) => {
+			headers[k] = v;
+		});
+
+		let body: unknown;
+		const text = await response.text();
+		try {
+			body = JSON.parse(text);
+		} catch {
+			body = text;
+		}
+
+		upstream = { status: response.status, headers, body };
+	} catch {
+		upstream = { status: 0, headers: {}, body: null };
+	}
+
+	await storage.put("upstream_response", upstream);
+	await storage.delete("forward_headers");
+
+	const envelope = buildEnvelope(job.id, job.request.target, upstream, new Date().toISOString());
+	await deliverAllCallbacks(storage, job, envelope);
+}
+
+/** Retry any pending callbacks triggered by an alarm. */
+export async function retryPendingCallbacks(
+	storage: DurableObjectStorage,
+	job: Job,
+): Promise<void> {
+	const upstreamResponse = await storage.get<UpstreamResponse>("upstream_response");
+	if (!upstreamResponse) return;
+
+	const retryPolicy = getRetryPolicy(job);
+	const envelope = buildEnvelope(
+		job.id,
+		job.request.target,
+		upstreamResponse,
+		new Date().toISOString(),
+	);
+
+	const now = Date.now();
+	let earliestRetry: number | null = null;
+
+	for (let i = 0; i < job.request.callbacks.length; i++) {
+		const state = await storage.get<CallbackState>(`cb:${i}`);
+		if (!state || state.status !== "pending") continue;
+
+		if (state.next_retry_at && state.next_retry_at > now) {
+			if (earliestRetry === null || state.next_retry_at < earliestRetry) {
+				earliestRetry = state.next_retry_at;
+			}
+			continue;
+		}
+
+		const success = await deliverOne(job.request.callbacks[i], envelope);
+		const newAttempts = state.attempts + 1;
+
+		if (success) {
+			await storage.put(`cb:${i}`, {
+				status: "delivered",
+				attempts: newAttempts,
+				next_retry_at: null,
+			} satisfies CallbackState);
+		} else if (shouldRetry(newAttempts, retryPolicy)) {
+			const delay = computeBackoff(state.attempts, retryPolicy);
+			const nextRetry = now + delay;
+			await storage.put(`cb:${i}`, {
+				status: "pending",
+				attempts: newAttempts,
+				next_retry_at: nextRetry,
+			} satisfies CallbackState);
+			if (earliestRetry === null || nextRetry < earliestRetry) earliestRetry = nextRetry;
+		} else {
+			await storage.put(`cb:${i}`, {
+				status: "failed",
+				attempts: newAttempts,
+				next_retry_at: null,
+			} satisfies CallbackState);
+		}
+	}
+
+	await resolveJobStatus(storage, job);
+	if (earliestRetry !== null) {
+		await storage.setAlarm(earliestRetry);
+	}
+}
+
+async function deliverAllCallbacks(
+	storage: DurableObjectStorage,
+	job: Job,
+	envelope: Envelope,
+): Promise<void> {
+	const retryPolicy = getRetryPolicy(job);
+
+	const results = await Promise.all(job.request.callbacks.map((cb) => deliverOne(cb, envelope)));
+
+	const now = Date.now();
+	let earliestRetry: number | null = null;
+
+	for (let i = 0; i < results.length; i++) {
+		let state: CallbackState;
+		if (results[i]) {
+			state = { status: "delivered", attempts: 1, next_retry_at: null };
+		} else if (shouldRetry(1, retryPolicy)) {
+			const delay = computeBackoff(0, retryPolicy);
+			const nextRetry = now + delay;
+			state = { status: "pending", attempts: 1, next_retry_at: nextRetry };
+			if (earliestRetry === null || nextRetry < earliestRetry) earliestRetry = nextRetry;
+		} else {
+			state = { status: "failed", attempts: 1, next_retry_at: null };
+		}
+		await storage.put(`cb:${i}`, state);
+	}
+
+	await resolveJobStatus(storage, job);
+	if (earliestRetry !== null) {
+		await storage.setAlarm(earliestRetry);
+	}
+}
+
+async function deliverOne(callback: Callback, envelope: Envelope): Promise<boolean> {
+	try {
+		const response = await fetch(callback.url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				...(callback.headers ?? {}),
+			},
+			body: JSON.stringify(envelope),
+		});
+		return response.status >= 200 && response.status < 300;
+	} catch {
+		return false;
+	}
+}
+
+async function resolveJobStatus(storage: DurableObjectStorage, job: Job): Promise<void> {
+	const states: CallbackState[] = [];
+	for (let i = 0; i < job.request.callbacks.length; i++) {
+		const state = await storage.get<CallbackState>(`cb:${i}`);
+		if (state) states.push(state);
+	}
+	if (states.length === 0) return;
+
+	if (states.every((s) => s.status === "delivered")) {
+		await updateStatus(storage, "completed");
+	} else if (
+		states.some((s) => s.status === "failed") &&
+		!states.some((s) => s.status === "pending")
+	) {
+		await updateStatus(storage, "failed");
+	}
+}
+
+async function updateStatus(storage: DurableObjectStorage, status: JobStatus): Promise<void> {
+	const job = await storage.get<Job>("job");
+	if (!job) return;
+	job.status = status;
+	job.updated_at = new Date().toISOString();
+	await storage.put("job", job);
+}
+
+function getRetryPolicy(job: Job): RetryPolicy {
+	return job.request.retry ?? DEFAULT_RETRY_POLICY;
+}

--- a/packages/cloudflare/src/http.ts
+++ b/packages/cloudflare/src/http.ts
@@ -1,0 +1,14 @@
+/** Serialize a request body for fetch. */
+export function serializeBody(body: unknown): BodyInit | null {
+	if (body === null || body === undefined) return null;
+	if (typeof body === "string") return body;
+	return JSON.stringify(body);
+}
+
+/** Create a JSON Response with the given status code. */
+export function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/packages/cloudflare/src/job-do.ts
+++ b/packages/cloudflare/src/job-do.ts
@@ -1,42 +1,15 @@
-import {
-	type Callback,
-	type Envelope,
-	type Job,
-	type JobStatus,
-	RequestBodySchema,
-	type RetryPolicy,
-	RetryPolicySchema,
-	type UpstreamResponse,
-	buildEnvelope,
-	computeBackoff,
-	shouldRetry,
-} from "@lampas/core";
+import { type Job, RequestBodySchema, type SsrfPolicy, parseSsrfPolicy } from "@lampas/core";
+import { type CallbackState, executeAndDeliver, retryPendingCallbacks } from "./delivery.js";
+import { jsonResponse } from "./http.js";
+import { validateRequestSsrf } from "./ssrf-guard.js";
 
-/** Per-callback delivery tracking state. */
-export interface CallbackState {
-	status: "pending" | "delivered" | "failed";
-	attempts: number;
-	next_retry_at: number | null;
-}
+export type { CallbackState };
 
 /** Cloudflare Worker environment bindings. */
 export interface Env {
 	JOB_DO: DurableObjectNamespace;
-}
-
-const DEFAULT_RETRY_POLICY: RetryPolicy = RetryPolicySchema.parse({});
-
-function serializeBody(body: unknown): BodyInit | null {
-	if (body === null || body === undefined) return null;
-	if (typeof body === "string") return body;
-	return JSON.stringify(body);
-}
-
-function jsonResponse(status: number, body: unknown): Response {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: { "Content-Type": "application/json" },
-	});
+	SSRF_BLOCK_PRIVATE?: string;
+	SSRF_ALLOWLIST?: string;
 }
 
 /** Durable Object that owns the full lifecycle of a Lampas job. */
@@ -61,9 +34,9 @@ export class JobDO implements DurableObject {
 		if (!job) return;
 
 		if (job.status === "queued") {
-			await this.executeAndDeliver(job);
+			await executeAndDeliver(this.ctx.storage, job);
 		} else if (job.status === "in_progress") {
-			await this.retryPendingCallbacks(job);
+			await retryPendingCallbacks(this.ctx.storage, job);
 		}
 	}
 
@@ -84,6 +57,15 @@ export class JobDO implements DurableObject {
 		if (!result.success) {
 			const messages = result.error.issues.map((i) => i.message);
 			return jsonResponse(400, { error: messages.join("; ") });
+		}
+
+		const ssrfCheck = await validateRequestSsrf(
+			result.data.target,
+			result.data.callbacks,
+			this.getSsrfPolicy(),
+		);
+		if (!ssrfCheck.ok) {
+			return jsonResponse(400, { error: `SSRF blocked: ${ssrfCheck.reason}` });
 		}
 
 		const now = new Date().toISOString();
@@ -110,187 +92,7 @@ export class JobDO implements DurableObject {
 		return jsonResponse(200, job);
 	}
 
-	private async executeAndDeliver(job: Job): Promise<void> {
-		await this.updateStatus("in_progress");
-
-		const forwardHeaders = await this.ctx.storage.get<Record<string, string>>("forward_headers");
-
-		let upstream: UpstreamResponse;
-		try {
-			const method = job.request.method ?? "POST";
-			const hasBody = method !== "GET" && method !== "HEAD";
-			const controller = new AbortController();
-			const timeoutMs = job.request.timeout_ms ?? 30000;
-			const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-			const response = await fetch(job.request.target, {
-				method,
-				headers: forwardHeaders ?? {},
-				body: hasBody ? serializeBody(job.request.body) : null,
-				signal: controller.signal,
-			});
-
-			clearTimeout(timer);
-
-			const headers: Record<string, string> = {};
-			response.headers.forEach((v, k) => {
-				headers[k] = v;
-			});
-
-			let body: unknown;
-			const text = await response.text();
-			try {
-				body = JSON.parse(text);
-			} catch {
-				body = text;
-			}
-
-			upstream = { status: response.status, headers, body };
-		} catch {
-			upstream = { status: 0, headers: {}, body: null };
-		}
-
-		await this.ctx.storage.put("upstream_response", upstream);
-		await this.ctx.storage.delete("forward_headers");
-
-		const envelope = buildEnvelope(job.id, job.request.target, upstream, new Date().toISOString());
-
-		await this.deliverAllCallbacks(job, envelope);
-	}
-
-	private async deliverAllCallbacks(job: Job, envelope: Envelope): Promise<void> {
-		const retryPolicy = this.getRetryPolicy(job);
-
-		const results = await Promise.all(
-			job.request.callbacks.map((cb) => this.deliverOne(cb, envelope)),
-		);
-
-		const now = Date.now();
-		let earliestRetry: number | null = null;
-
-		for (let i = 0; i < results.length; i++) {
-			let state: CallbackState;
-			if (results[i]) {
-				state = { status: "delivered", attempts: 1, next_retry_at: null };
-			} else if (shouldRetry(1, retryPolicy)) {
-				const delay = computeBackoff(0, retryPolicy);
-				const nextRetry = now + delay;
-				state = { status: "pending", attempts: 1, next_retry_at: nextRetry };
-				if (earliestRetry === null || nextRetry < earliestRetry) earliestRetry = nextRetry;
-			} else {
-				state = { status: "failed", attempts: 1, next_retry_at: null };
-			}
-			await this.ctx.storage.put(`cb:${i}`, state);
-		}
-
-		await this.resolveJobStatus(job);
-		if (earliestRetry !== null) {
-			await this.ctx.storage.setAlarm(earliestRetry);
-		}
-	}
-
-	private async retryPendingCallbacks(job: Job): Promise<void> {
-		const upstreamResponse = await this.ctx.storage.get<UpstreamResponse>("upstream_response");
-		if (!upstreamResponse) return;
-
-		const retryPolicy = this.getRetryPolicy(job);
-		const envelope = buildEnvelope(
-			job.id,
-			job.request.target,
-			upstreamResponse,
-			new Date().toISOString(),
-		);
-
-		const now = Date.now();
-		let earliestRetry: number | null = null;
-
-		for (let i = 0; i < job.request.callbacks.length; i++) {
-			const state = await this.ctx.storage.get<CallbackState>(`cb:${i}`);
-			if (!state || state.status !== "pending") continue;
-
-			if (state.next_retry_at && state.next_retry_at > now) {
-				if (earliestRetry === null || state.next_retry_at < earliestRetry) {
-					earliestRetry = state.next_retry_at;
-				}
-				continue;
-			}
-
-			const success = await this.deliverOne(job.request.callbacks[i], envelope);
-			const newAttempts = state.attempts + 1;
-
-			if (success) {
-				await this.ctx.storage.put(`cb:${i}`, {
-					status: "delivered",
-					attempts: newAttempts,
-					next_retry_at: null,
-				} satisfies CallbackState);
-			} else if (shouldRetry(newAttempts, retryPolicy)) {
-				const delay = computeBackoff(state.attempts, retryPolicy);
-				const nextRetry = now + delay;
-				await this.ctx.storage.put(`cb:${i}`, {
-					status: "pending",
-					attempts: newAttempts,
-					next_retry_at: nextRetry,
-				} satisfies CallbackState);
-				if (earliestRetry === null || nextRetry < earliestRetry) earliestRetry = nextRetry;
-			} else {
-				await this.ctx.storage.put(`cb:${i}`, {
-					status: "failed",
-					attempts: newAttempts,
-					next_retry_at: null,
-				} satisfies CallbackState);
-			}
-		}
-
-		await this.resolveJobStatus(job);
-		if (earliestRetry !== null) {
-			await this.ctx.storage.setAlarm(earliestRetry);
-		}
-	}
-
-	private async deliverOne(callback: Callback, envelope: Envelope): Promise<boolean> {
-		try {
-			const response = await fetch(callback.url, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					...(callback.headers ?? {}),
-				},
-				body: JSON.stringify(envelope),
-			});
-			return response.status >= 200 && response.status < 300;
-		} catch {
-			return false;
-		}
-	}
-
-	private async resolveJobStatus(job: Job): Promise<void> {
-		const states: CallbackState[] = [];
-		for (let i = 0; i < job.request.callbacks.length; i++) {
-			const state = await this.ctx.storage.get<CallbackState>(`cb:${i}`);
-			if (state) states.push(state);
-		}
-		if (states.length === 0) return;
-
-		if (states.every((s) => s.status === "delivered")) {
-			await this.updateStatus("completed");
-		} else if (
-			states.some((s) => s.status === "failed") &&
-			!states.some((s) => s.status === "pending")
-		) {
-			await this.updateStatus("failed");
-		}
-	}
-
-	private async updateStatus(status: JobStatus): Promise<void> {
-		const job = await this.ctx.storage.get<Job>("job");
-		if (!job) return;
-		job.status = status;
-		job.updated_at = new Date().toISOString();
-		await this.ctx.storage.put("job", job);
-	}
-
-	private getRetryPolicy(job: Job): RetryPolicy {
-		return job.request.retry ?? DEFAULT_RETRY_POLICY;
+	private getSsrfPolicy(): SsrfPolicy {
+		return parseSsrfPolicy(this.env.SSRF_BLOCK_PRIVATE, this.env.SSRF_ALLOWLIST);
 	}
 }

--- a/packages/cloudflare/src/ssrf-guard.ts
+++ b/packages/cloudflare/src/ssrf-guard.ts
@@ -1,0 +1,96 @@
+import {
+	type Callback,
+	type SsrfPolicy,
+	type SsrfResult,
+	parseIp,
+	validateIp,
+	validateUrl,
+} from "@lampas/core";
+
+interface DnsJsonResponse {
+	Answer?: { type: number; data: string }[];
+}
+
+/** DNS record types: A=1, AAAA=28. */
+const DNS_RECORD_TYPES = [1, 28] as const;
+
+/** Resolve a hostname to IP addresses via Cloudflare DNS-over-HTTPS. */
+export async function resolveHostname(hostname: string): Promise<string[]> {
+	const queries = ["A", "AAAA"].map(async (type) => {
+		const params = new URLSearchParams({ name: hostname, type });
+		const resp = await fetch(`https://cloudflare-dns.com/dns-query?${params}`, {
+			headers: { Accept: "application/dns-json" },
+		});
+		return (await resp.json()) as DnsJsonResponse;
+	});
+
+	const [aData, aaaaData] = await Promise.all(queries);
+	const ips: string[] = [];
+	for (const answer of [...(aData.Answer ?? []), ...(aaaaData.Answer ?? [])]) {
+		if (DNS_RECORD_TYPES.includes(answer.type as 1 | 28)) {
+			ips.push(answer.data);
+		}
+	}
+	return ips;
+}
+
+/**
+ * Validate a single URL against SSRF policy, including DNS resolution.
+ *
+ * Fails open on DNS resolution errors — CF Workers provide additional
+ * protection at the fetch layer.
+ */
+async function validateUrlWithDns(
+	url: string,
+	policy: SsrfPolicy,
+	resolver: (hostname: string) => Promise<string[]>,
+): Promise<SsrfResult> {
+	const urlCheck = validateUrl(url, policy);
+	if (!urlCheck.ok) return urlCheck;
+	if (!policy.blockPrivate) return { ok: true };
+
+	const parsed = new URL(url);
+	const hostname =
+		parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
+			? parsed.hostname.slice(1, -1)
+			: parsed.hostname;
+
+	if (parseIp(hostname)) return { ok: true };
+
+	let ips: string[];
+	try {
+		ips = await resolver(hostname);
+	} catch {
+		return { ok: true };
+	}
+
+	for (const ip of ips) {
+		const result = validateIp(ip, policy);
+		if (!result.ok) {
+			return { ok: false, reason: `${hostname} resolves to blocked IP: ${ip}` };
+		}
+	}
+	return { ok: true };
+}
+
+/**
+ * Validate all URLs in a request (target + callbacks) against the SSRF policy.
+ *
+ * Returns the first failure or `{ ok: true }` if all pass.
+ */
+export async function validateRequestSsrf(
+	target: string,
+	callbacks: Callback[],
+	policy: SsrfPolicy,
+	resolver: (hostname: string) => Promise<string[]> = resolveHostname,
+): Promise<SsrfResult> {
+	if (!policy.blockPrivate) return { ok: true };
+
+	const urls = [target, ...callbacks.map((cb) => cb.url)];
+	const results = await Promise.all(urls.map((url) => validateUrlWithDns(url, policy, resolver)));
+
+	for (const result of results) {
+		if (!result.ok) return result;
+	}
+	return { ok: true };
+}

--- a/packages/cloudflare/wrangler.toml
+++ b/packages/cloudflare/wrangler.toml
@@ -9,3 +9,7 @@ class_name = "JobDO"
 [[migrations]]
 tag = "v1"
 new_classes = ["JobDO"]
+
+[vars]
+SSRF_BLOCK_PRIVATE = "true"
+SSRF_ALLOWLIST = ""

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,18 @@ export {
 } from "./job";
 
 export { type RetryState, computeBackoff, shouldRetry } from "./retry";
+
+export {
+	BLOCKED_CIDRS,
+	type CidrRange,
+	type SsrfPolicy,
+	type SsrfResult,
+	ipInCidr,
+	parseCidr,
+	parseIp,
+	parseIpv4,
+	parseIpv6,
+	parseSsrfPolicy,
+	validateIp,
+	validateUrl,
+} from "./ssrf";

--- a/packages/core/src/ssrf.test.ts
+++ b/packages/core/src/ssrf.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+	BLOCKED_CIDRS,
+	type SsrfPolicy,
+	ipInCidr,
+	parseCidr,
+	parseIp,
+	parseIpv4,
+	parseIpv6,
+	parseSsrfPolicy,
+	validateIp,
+	validateUrl,
+} from "./ssrf";
+
+const POLICY_ON: SsrfPolicy = { blockPrivate: true, allowlist: [] };
+const POLICY_OFF: SsrfPolicy = { blockPrivate: false, allowlist: [] };
+
+/** Parse an IP, throwing if invalid (avoids non-null assertions in tests). */
+function ip(addr: string): Uint8Array {
+	const result = parseIp(addr);
+	if (!result) throw new Error(`Test setup error: invalid IP ${addr}`);
+	return result;
+}
+
+describe("parseIpv4", () => {
+	it("parses valid addresses", () => {
+		expect(parseIpv4("0.0.0.0")).toEqual(new Uint8Array([0, 0, 0, 0]));
+		expect(parseIpv4("192.168.1.1")).toEqual(new Uint8Array([192, 168, 1, 1]));
+		expect(parseIpv4("255.255.255.255")).toEqual(new Uint8Array([255, 255, 255, 255]));
+	});
+
+	it("rejects invalid addresses", () => {
+		expect(parseIpv4("")).toBeNull();
+		expect(parseIpv4("1.2.3")).toBeNull();
+		expect(parseIpv4("1.2.3.4.5")).toBeNull();
+		expect(parseIpv4("256.0.0.0")).toBeNull();
+		expect(parseIpv4("1.2.3.04")).toBeNull();
+		expect(parseIpv4("abc.def.ghi.jkl")).toBeNull();
+	});
+});
+
+describe("parseIpv6", () => {
+	it("parses full addresses", () => {
+		const result = parseIpv6("2001:0db8:0000:0000:0000:0000:0000:0001");
+		expect(result).not.toBeNull();
+		expect(result?.[0]).toBe(0x20);
+		expect(result?.[1]).toBe(0x01);
+	});
+
+	it("parses compressed addresses", () => {
+		expect(parseIpv6("::1")).not.toBeNull();
+		expect(parseIpv6("::")).not.toBeNull();
+		expect(parseIpv6("fe80::1")).not.toBeNull();
+	});
+
+	it("parses v4-mapped addresses", () => {
+		const result = parseIpv6("::ffff:192.168.1.1");
+		expect(result).not.toBeNull();
+		expect(result?.[12]).toBe(192);
+		expect(result?.[13]).toBe(168);
+		expect(result?.[14]).toBe(1);
+		expect(result?.[15]).toBe(1);
+	});
+
+	it("rejects invalid addresses", () => {
+		expect(parseIpv6("")).toBeNull();
+		expect(parseIpv6(":::1")).toBeNull();
+		expect(parseIpv6("1:2:3:4:5:6:7:8:9")).toBeNull();
+		expect(parseIpv6("gggg::1")).toBeNull();
+	});
+});
+
+describe("parseIp", () => {
+	it("detects v4 and v6", () => {
+		expect(parseIp("10.0.0.1")?.length).toBe(4);
+		expect(parseIp("::1")?.length).toBe(16);
+		expect(parseIp("not-an-ip")).toBeNull();
+	});
+});
+
+describe("parseCidr", () => {
+	it("parses valid CIDR", () => {
+		const range = parseCidr("10.0.0.0/8");
+		expect(range.bytes).toEqual(new Uint8Array([10, 0, 0, 0]));
+		expect(range.prefixLength).toBe(8);
+	});
+
+	it("throws on invalid CIDR", () => {
+		expect(() => parseCidr("10.0.0.0")).toThrow("missing prefix");
+		expect(() => parseCidr("bad/8")).toThrow("Invalid IP");
+		expect(() => parseCidr("10.0.0.0/33")).toThrow("Invalid prefix");
+	});
+});
+
+describe("ipInCidr", () => {
+	it("matches IPs in range", () => {
+		const cidr = parseCidr("10.0.0.0/8");
+		expect(ipInCidr(ip("10.0.0.1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("10.255.255.255"), cidr)).toBe(true);
+		expect(ipInCidr(ip("11.0.0.0"), cidr)).toBe(false);
+	});
+
+	it("handles /16 prefix", () => {
+		const cidr = parseCidr("192.168.0.0/16");
+		expect(ipInCidr(ip("192.168.1.1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("192.169.0.0"), cidr)).toBe(false);
+	});
+
+	it("handles /12 prefix with partial byte", () => {
+		const cidr = parseCidr("172.16.0.0/12");
+		expect(ipInCidr(ip("172.16.0.1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("172.31.255.255"), cidr)).toBe(true);
+		expect(ipInCidr(ip("172.32.0.0"), cidr)).toBe(false);
+	});
+
+	it("handles IPv6 ranges", () => {
+		const cidr = parseCidr("fc00::/7");
+		expect(ipInCidr(ip("fc00::1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("fdff::1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("fe00::1"), cidr)).toBe(false);
+	});
+
+	it("handles loopback ::1/128", () => {
+		const cidr = parseCidr("::1/128");
+		expect(ipInCidr(ip("::1"), cidr)).toBe(true);
+		expect(ipInCidr(ip("::2"), cidr)).toBe(false);
+	});
+});
+
+describe("validateUrl", () => {
+	it("allows public HTTP(S) URLs", () => {
+		expect(validateUrl("https://api.example.com/data", POLICY_ON).ok).toBe(true);
+		expect(validateUrl("http://webhook.site/abc", POLICY_ON).ok).toBe(true);
+	});
+
+	it("blocks non-HTTP schemes", () => {
+		const r1 = validateUrl("file:///etc/passwd", POLICY_ON);
+		expect(r1.ok).toBe(false);
+		if (!r1.ok) expect(r1.reason).toContain("Blocked scheme");
+
+		const r2 = validateUrl("ftp://internal/file", POLICY_ON);
+		expect(r2.ok).toBe(false);
+	});
+
+	it("blocks private IPv4 addresses in URL", () => {
+		expect(validateUrl("http://127.0.0.1/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://10.0.0.1/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://192.168.1.1/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://172.16.0.1/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://169.254.169.254/metadata", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://0.0.0.1/path", POLICY_ON).ok).toBe(false);
+	});
+
+	it("blocks private IPv6 addresses in URL", () => {
+		expect(validateUrl("http://[::1]/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://[fc00::1]/path", POLICY_ON).ok).toBe(false);
+		expect(validateUrl("http://[fe80::1]/path", POLICY_ON).ok).toBe(false);
+	});
+
+	it("allows public IPs", () => {
+		expect(validateUrl("http://93.184.216.34/path", POLICY_ON).ok).toBe(true);
+		expect(validateUrl("http://8.8.8.8/dns", POLICY_ON).ok).toBe(true);
+	});
+
+	it("skips validation when policy is off", () => {
+		expect(validateUrl("http://127.0.0.1/path", POLICY_OFF).ok).toBe(true);
+		expect(validateUrl("file:///etc/passwd", POLICY_OFF).ok).toBe(true);
+	});
+
+	it("allows domain hostnames (DNS not resolved here)", () => {
+		expect(validateUrl("https://evil.attacker.com/path", POLICY_ON).ok).toBe(true);
+	});
+});
+
+describe("validateIp", () => {
+	it("blocks private IPs", () => {
+		expect(validateIp("127.0.0.1", POLICY_ON).ok).toBe(false);
+		expect(validateIp("10.0.0.1", POLICY_ON).ok).toBe(false);
+		expect(validateIp("::1", POLICY_ON).ok).toBe(false);
+	});
+
+	it("allows public IPs", () => {
+		expect(validateIp("93.184.216.34", POLICY_ON).ok).toBe(true);
+		expect(validateIp("2606:2800:220:1:248:1893:25c8:1946", POLICY_ON).ok).toBe(true);
+	});
+
+	it("rejects invalid IP strings", () => {
+		const result = validateIp("not-an-ip", POLICY_ON);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("Invalid IP");
+	});
+});
+
+describe("parseSsrfPolicy", () => {
+	it("defaults to blocking enabled, empty allowlist", () => {
+		const policy = parseSsrfPolicy();
+		expect(policy.blockPrivate).toBe(true);
+		expect(policy.allowlist).toEqual([]);
+	});
+
+	it("respects SSRF_BLOCK_PRIVATE=false", () => {
+		expect(parseSsrfPolicy("false").blockPrivate).toBe(false);
+	});
+
+	it("treats any non-false value as true", () => {
+		expect(parseSsrfPolicy("true").blockPrivate).toBe(true);
+		expect(parseSsrfPolicy("yes").blockPrivate).toBe(true);
+		expect(parseSsrfPolicy("").blockPrivate).toBe(true);
+	});
+
+	it("parses comma-separated CIDR allowlist", () => {
+		const policy = parseSsrfPolicy("true", "10.0.0.0/8, 172.16.0.0/12");
+		expect(policy.allowlist).toHaveLength(2);
+	});
+
+	it("ignores empty entries in allowlist", () => {
+		const policy = parseSsrfPolicy("true", "10.0.0.0/8,,");
+		expect(policy.allowlist).toHaveLength(1);
+	});
+});
+
+describe("allowlist overrides", () => {
+	it("allows private IPs that are in the allowlist", () => {
+		const policy: SsrfPolicy = {
+			blockPrivate: true,
+			allowlist: [parseCidr("10.0.0.0/8")],
+		};
+		expect(validateIp("10.0.0.1", policy).ok).toBe(true);
+		expect(validateUrl("http://10.0.0.1/path", policy).ok).toBe(true);
+	});
+
+	it("still blocks other private ranges not in allowlist", () => {
+		const policy: SsrfPolicy = {
+			blockPrivate: true,
+			allowlist: [parseCidr("10.0.0.0/8")],
+		};
+		expect(validateIp("192.168.1.1", policy).ok).toBe(false);
+		expect(validateIp("127.0.0.1", policy).ok).toBe(false);
+	});
+});
+
+describe("all blocked CIDRs are parseable", () => {
+	it("parses every default range", () => {
+		for (const cidr of BLOCKED_CIDRS) {
+			expect(() => parseCidr(cidr)).not.toThrow();
+		}
+	});
+});

--- a/packages/core/src/ssrf.ts
+++ b/packages/core/src/ssrf.ts
@@ -1,0 +1,223 @@
+/** A parsed CIDR range for IP matching. */
+export interface CidrRange {
+	readonly bytes: Uint8Array;
+	readonly prefixLength: number;
+}
+
+/** SSRF protection policy configuration. */
+export interface SsrfPolicy {
+	readonly blockPrivate: boolean;
+	readonly allowlist: readonly CidrRange[];
+}
+
+/** Result of SSRF validation. */
+export type SsrfResult = { ok: true } | { ok: false; reason: string };
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+/** Default private/reserved CIDR ranges blocked by SSRF policy. */
+export const BLOCKED_CIDRS: readonly string[] = [
+	"0.0.0.0/8",
+	"10.0.0.0/8",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"::1/128",
+	"fc00::/7",
+	"fe80::/10",
+];
+
+/** Parse an IPv4 address string to 4 bytes. Returns null if invalid. */
+export function parseIpv4(ip: string): Uint8Array | null {
+	const parts = ip.split(".");
+	if (parts.length !== 4) return null;
+	const bytes = new Uint8Array(4);
+	for (let i = 0; i < 4; i++) {
+		const n = Number(parts[i]);
+		if (!Number.isInteger(n) || n < 0 || n > 255 || parts[i] !== String(n)) return null;
+		bytes[i] = n;
+	}
+	return bytes;
+}
+
+/** Parse an IPv6 address string to 16 bytes. Returns null if invalid. */
+export function parseIpv6(ip: string): Uint8Array | null {
+	const v4Mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+	if (v4Mapped) {
+		const v4 = parseIpv4(v4Mapped[1]);
+		if (!v4) return null;
+		const bytes = new Uint8Array(16);
+		bytes[10] = 0xff;
+		bytes[11] = 0xff;
+		bytes.set(v4, 12);
+		return bytes;
+	}
+
+	const halves = ip.split("::");
+	if (halves.length > 2) return null;
+
+	const left = halves[0] ? halves[0].split(":") : [];
+	const right = halves.length === 2 ? (halves[1] ? halves[1].split(":") : []) : [];
+
+	if (halves.length === 1 && left.length !== 8) return null;
+	if (left.length + right.length > 8) return null;
+
+	const groups: number[] = [];
+	for (const g of left) {
+		if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+		groups.push(Number.parseInt(g, 16));
+	}
+	const missing = 8 - left.length - right.length;
+	for (let i = 0; i < missing; i++) groups.push(0);
+	for (const g of right) {
+		if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+		groups.push(Number.parseInt(g, 16));
+	}
+
+	if (groups.length !== 8) return null;
+	const bytes = new Uint8Array(16);
+	for (let i = 0; i < 8; i++) {
+		bytes[i * 2] = (groups[i] >> 8) & 0xff;
+		bytes[i * 2 + 1] = groups[i] & 0xff;
+	}
+	return bytes;
+}
+
+/** Parse an IP address (v4 or v6) to bytes. Returns null if not a valid IP. */
+export function parseIp(ip: string): Uint8Array | null {
+	return parseIpv4(ip) ?? parseIpv6(ip);
+}
+
+/** Parse a CIDR notation string into a CidrRange. Throws on invalid input. */
+export function parseCidr(cidr: string): CidrRange {
+	const slash = cidr.lastIndexOf("/");
+	if (slash === -1) throw new Error(`Invalid CIDR (missing prefix): ${cidr}`);
+	const ipStr = cidr.slice(0, slash);
+	const bytes = parseIp(ipStr);
+	if (!bytes) throw new Error(`Invalid IP in CIDR: ${cidr}`);
+	const prefixLength = Number(cidr.slice(slash + 1));
+	const maxPrefix = bytes.length === 4 ? 32 : 128;
+	if (!Number.isInteger(prefixLength) || prefixLength < 0 || prefixLength > maxPrefix) {
+		throw new Error(`Invalid prefix length in CIDR: ${cidr}`);
+	}
+	return { bytes, prefixLength };
+}
+
+/** Check if an IP (as bytes) falls within a CIDR range. */
+export function ipInCidr(ip: Uint8Array, cidr: CidrRange): boolean {
+	let ipBytes = ip;
+	let cidrBytes = cidr.bytes;
+	let { prefixLength } = cidr;
+
+	if (ipBytes.length !== cidrBytes.length) {
+		if (ipBytes.length === 4 && cidrBytes.length === 16) {
+			const expanded = new Uint8Array(16);
+			expanded[10] = 0xff;
+			expanded[11] = 0xff;
+			expanded.set(ipBytes, 12);
+			ipBytes = expanded;
+		} else if (ipBytes.length === 16 && cidrBytes.length === 4) {
+			const expanded = new Uint8Array(16);
+			expanded[10] = 0xff;
+			expanded[11] = 0xff;
+			expanded.set(cidrBytes, 12);
+			cidrBytes = expanded;
+			prefixLength += 96;
+		} else {
+			return false;
+		}
+	}
+
+	const fullBytes = Math.floor(prefixLength / 8);
+	for (let i = 0; i < fullBytes; i++) {
+		if (ipBytes[i] !== cidrBytes[i]) return false;
+	}
+	const remainingBits = prefixLength % 8;
+	if (remainingBits > 0) {
+		const mask = 0xff << (8 - remainingBits);
+		if ((ipBytes[fullBytes] & mask) !== (cidrBytes[fullBytes] & mask)) return false;
+	}
+	return true;
+}
+
+let _blockedRanges: CidrRange[] | null = null;
+function getBlockedRanges(): CidrRange[] {
+	if (!_blockedRanges) _blockedRanges = BLOCKED_CIDRS.map(parseCidr);
+	return _blockedRanges;
+}
+
+function validateIpBytes(bytes: Uint8Array, policy: SsrfPolicy): SsrfResult {
+	if (policy.allowlist.some((cidr) => ipInCidr(bytes, cidr))) return { ok: true };
+	if (getBlockedRanges().some((cidr) => ipInCidr(bytes, cidr))) {
+		return { ok: false, reason: "IP address is in a blocked private/reserved range" };
+	}
+	return { ok: true };
+}
+
+/**
+ * Extract the scheme from a URL string.
+ * Returns the scheme including the colon (e.g. "https:"), or null if unparseable.
+ */
+function extractScheme(url: string): string | null {
+	const match = url.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*:)/);
+	return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Extract the hostname from a URL string.
+ * Handles `scheme://[ipv6]:port/path` and `scheme://host:port/path`.
+ */
+function extractHostname(url: string): string | null {
+	const authorityStart = url.indexOf("://");
+	if (authorityStart === -1) return null;
+	const rest = url.slice(authorityStart + 3);
+
+	if (rest.startsWith("[")) {
+		const bracketEnd = rest.indexOf("]");
+		if (bracketEnd === -1) return null;
+		return rest.slice(1, bracketEnd);
+	}
+
+	const hostEnd = rest.search(/[:/]/);
+	return hostEnd === -1 ? rest : rest.slice(0, hostEnd);
+}
+
+/** Validate a URL for SSRF safety (scheme and raw-IP hostname check). Does not resolve DNS. */
+export function validateUrl(url: string, policy: SsrfPolicy): SsrfResult {
+	if (!policy.blockPrivate) return { ok: true };
+
+	const scheme = extractScheme(url);
+	if (!scheme) return { ok: false, reason: "Invalid URL" };
+	if (!ALLOWED_SCHEMES.has(scheme)) {
+		return { ok: false, reason: `Blocked scheme: ${scheme}` };
+	}
+
+	const hostname = extractHostname(url);
+	if (!hostname) return { ok: false, reason: "Invalid URL" };
+
+	const bytes = parseIp(hostname);
+	if (!bytes) return { ok: true };
+	return validateIpBytes(bytes, policy);
+}
+
+/** Validate a resolved IP address string against the SSRF policy. */
+export function validateIp(ip: string, policy: SsrfPolicy): SsrfResult {
+	if (!policy.blockPrivate) return { ok: true };
+	const bytes = parseIp(ip);
+	if (!bytes) return { ok: false, reason: `Invalid IP address: ${ip}` };
+	return validateIpBytes(bytes, policy);
+}
+
+/** Parse SSRF policy from environment variable strings. */
+export function parseSsrfPolicy(blockPrivate?: string, allowlistCsv?: string): SsrfPolicy {
+	const block = blockPrivate !== "false";
+	const allowlist: CidrRange[] = [];
+	if (allowlistCsv) {
+		for (const cidr of allowlistCsv.split(",")) {
+			const trimmed = cidr.trim();
+			if (trimmed) allowlist.push(parseCidr(trimmed));
+		}
+	}
+	return { blockPrivate: block, allowlist };
+}


### PR DESCRIPTION
Closes #22

## What this does

Adds SSRF protection that blocks private/reserved IP ranges by default on all target and callback URLs. Validates URL schemes (HTTP/HTTPS only), raw IP hostnames against a deny list, and resolved IPs via Cloudflare DNS-over-HTTPS. Self-hosted deployments can punch holes for internal ranges via `SSRF_ALLOWLIST` env var.

Also refactors `job-do.ts` by extracting the delivery pipeline into `delivery.ts` and HTTP helpers into `http.ts` — the original file was at 297 lines and would have exceeded the 300-line limit with SSRF additions.

## Design alignment

- **Credentials are never stored**: SSRF policy is deployment-level config (env vars), not stored per-request. No change to the credential handling model.
- **Core defines the backend contract**: IP parsing, CIDR matching, and URL validation live in `@lampas/core`. The Cloudflare package adds DNS-over-HTTPS resolution on top.

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `core/src/ssrf.ts` | 223 | IPv4/IPv6 parsing, CIDR matching, URL validation, policy config |
| `core/src/ssrf.test.ts` | 248 | 32 tests covering all blocked ranges, allowlist overrides, edge cases |
| `cloudflare/src/ssrf-guard.ts` | 96 | DNS-over-HTTPS resolution + request-level SSRF validation |
| `cloudflare/src/delivery.ts` | 212 | Extracted: upstream execution, callback delivery, retry logic |
| `cloudflare/src/http.ts` | 14 | Extracted: `serializeBody`, `jsonResponse` helpers |

## Blocked ranges

`0.0.0.0/8`, `10.0.0.0/8`, `127.0.0.0/8`, `169.254.0.0/16`, `172.16.0.0/12`, `192.168.0.0/16`, `::1/128`, `fc00::/7`, `fe80::/10`

## Configuration

- `SSRF_BLOCK_PRIVATE` (default `"true"`) — set to `"false"` to disable
- `SSRF_ALLOWLIST` (default `""`) — comma-separated CIDRs to exempt (e.g. `"10.0.0.0/8"`)

## Validation performed

- `npm run build` — passes (core, cloudflare, site)
- `npm run check` — passes (biome lint + format)
- `npm test` — all 102 tests pass (67 core, 24 cloudflare unit, 11 e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)